### PR TITLE
swap method improved to use bitwise xor instead of a temporary variable

### DIFF
--- a/call-by-reference/callbyreference.cpp
+++ b/call-by-reference/callbyreference.cpp
@@ -2,10 +2,9 @@
 using namespace std;
 void swap(int &a, int &b)
 {
-    int temp;
-    temp = a;
-    a = b; 
-    b = temp; 
+    a^=b;
+    b^=a;
+    a^=b; 
 
     return;
 }


### PR DESCRIPTION
Using xor this way, you can swap integers (long long and char works too) without the use of a auxiliar variable.