### PR TITLE
Added roman numerals converter (up to 5000) in PHP

### DIFF
--- a/roman/RomanNumeralsConverter.php
+++ b/roman/RomanNumeralsConverter.php
@@ -1,0 +1,34 @@
+<?php
+
+class RomanNumeralsConverter
+{
+    protected static $lookup = [
+        1000    => 'M',
+        900     => 'CM',
+        500     => 'D',
+        400     => 'CD',
+        100     => 'C',
+        90      => 'XC',
+        50      => 'L',
+        40      => 'XL',
+        10      => 'X',
+        9       => 'IX',
+        5       => 'V',
+        4       => 'IV',
+        1       => 'I'
+    ];
+
+    public function convert($number)
+    {
+        $solution = '';
+
+        foreach (static::$lookup as $arabicNumber => $romanNumeral) {
+            while ($number >= $arabicNumber) {
+                $solution .= $romanNumeral;
+                $number -= $arabicNumber;
+            }
+        }
+
+        return $solution;
+    }
+}


### PR DESCRIPTION
This PHP class can convert arabic numbers to roman numerals up to 5000. 
Resolve #98 

TDD:
As described by Jeffrey Way in https://laracasts.com/series/code-katas-in-php/episodes/2. 